### PR TITLE
Fix NCCL2 patch to remove using old methods

### DIFF
--- a/run_cupy_combination_test.py
+++ b/run_cupy_combination_test.py
@@ -12,8 +12,7 @@ import version
 
 params = {
     'base': docker.base_choices,
-    'cuda_cudnn': docker.get_cuda_cudnn_choices('cupy'),
-    'nccl': docker.nccl_choices,
+    'cuda_cudnn_nccl': docker.get_cuda_cudnn_nccl_choices('cupy'),
     'numpy': docker.get_numpy_choices(),
     'scipy': [None, '0.19'],
 }

--- a/run_cupy_install_test.py
+++ b/run_cupy_install_test.py
@@ -10,8 +10,7 @@ import shuffle
 
 params = {
     'base': docker.base_choices,
-    'cuda_cudnn': docker.get_cuda_cudnn_choices('cupy', with_dummy=True),
-    'nccl': docker.nccl_choices,
+    'cuda_cudnn_nccl': docker.get_cuda_cudnn_nccl_choices('cupy', with_dummy=True),
     'numpy': ['1.9', '1.10', '1.11', '1.12'],
     'cython': [None, '0.26.1', '0.27.1'],
     'pip': [None, '7', '8', '9'],

--- a/run_install_test.py
+++ b/run_install_test.py
@@ -10,8 +10,7 @@ import shuffle
 
 params = {
     'base': docker.base_choices,
-    'cuda_cudnn': docker.get_cuda_cudnn_choices('chainer', with_dummy=True),
-    'nccl': docker.nccl_choices,
+    'cuda_cudnn_nccl': docker.get_cuda_cudnn_nccl_choices('chainer', with_dummy=True),
     'numpy': ['1.9', '1.10', '1.11', '1.12'],
     'cython': [None, '0.26.1', '0.27.1'],
     'pip': [None, '7', '8', '9'],


### PR DESCRIPTION
Some scripts are still using `get_cuda_cudnn_choices` methods.